### PR TITLE
fix: resolve TypeScript errors blocking deploy

### DIFF
--- a/src/components/projectWizard/actions.ts
+++ b/src/components/projectWizard/actions.ts
@@ -1,8 +1,8 @@
-import { createPerson } from '@/api/people';
-import { createProfessor } from '@/api/professors';
-import { createStudent, setStudentCareers } from '@/api/students';
-import { createProject, setProjectApplicationDomain, setProjectParticipants, deleteProject } from '@/api/projects';
-import type { ProjectDraft, PersonBase, StudentDraft } from './types';
+import { createPerson } from '@/api/people'
+import { createProfessor } from '@/api/professors'
+import { createStudent } from '@/api/students'
+import { createProject, setProjectApplicationDomain, setProjectParticipants, deleteProject } from '@/api/projects'
+import type { ProjectDraft, PersonBase, StudentDraft } from './types'
 
 export function isTemp(publicId?: string) { return !publicId || publicId.startsWith('manual-'); }
 export function requirePublicId(obj: { publicId?: string; id?: string }): string { const pid = obj.publicId || obj.id; if(!pid) throw new Error('Missing publicId'); return pid; }

--- a/src/test/buildParticipants.test.ts
+++ b/src/test/buildParticipants.test.ts
@@ -17,22 +17,25 @@ describe('buildParticipants', () => {
   });
   it('deduplicates same person across roles', () => {
     const draft = makeDraft({
-      directors: [{ publicId: 'p1', name:'A', lastname:'B' }],
-      codirectors: [{ publicId: 'p1', name:'A', lastname:'B' }],
-      students: [{ publicId: 'p1', name:'A', lastname:'B', studentId:'s1', careers: [] } as any],
-    });
-    const result = buildParticipants(draft);
+      directors: [{ publicId: 'p1', name: 'A', lastname: 'B', email: 'a@b.com' }],
+      codirectors: [{ publicId: 'p1', name: 'A', lastname: 'B', email: 'a@b.com' }],
+      students: [{ publicId: 'p1', name: 'A', lastname: 'B', email: 'a@b.com', studentId: 's1', careers: [] } as any],
+    })
+    const result = buildParticipants(draft)
     // Person appears in multiple roles so expect 3 entries with unique role combos
-    expect(result.filter(r => r.personId==='p1').map(r=>r.role).sort()).toEqual(['CO_DIRECTOR','DIRECTOR','STUDENT']);
-  });
+    expect(result.filter((r) => r.personId === 'p1').map((r) => r.role).sort()).toEqual(['CO_DIRECTOR', 'DIRECTOR', 'STUDENT'])
+  })
   it('handles multiple distinct participants', () => {
     const draft = makeDraft({
-      directors: [{ publicId: 'd1', name:'D', lastname:'1' }],
-      collaborators: [{ publicId: 'c1', name:'C', lastname:'1' }],
-      students: [ { publicId: 's1', name:'S', lastname:'1', studentId: 'X', careers: [] } as any ],
-    });
-    const result = buildParticipants(draft);
-    const roles = result.reduce<Record<string,string[]>>((acc,p)=>{acc[p.personId]=(acc[p.personId]||[]).concat(p.role);return acc;},{});
+      directors: [{ publicId: 'd1', name: 'D', lastname: '1', email: 'd1@b.com' }],
+      collaborators: [{ publicId: 'c1', name: 'C', lastname: '1', email: 'c1@b.com' }],
+      students: [{ publicId: 's1', name: 'S', lastname: '1', email: 's1@b.com', studentId: 'X', careers: [] } as any],
+    })
+    const result = buildParticipants(draft)
+    const roles = result.reduce<Record<string, string[]>>((acc, p) => {
+      acc[p.personId] = (acc[p.personId] || []).concat(p.role)
+      return acc
+    }, {})
     expect(roles).toEqual({ d1:['DIRECTOR'], c1:['COLLABORATOR'], s1:['STUDENT'] });
   });
 });


### PR DESCRIPTION
Fixed two TypeScript compilation errors:

1. src/components/projectWizard/actions.ts
   - Removed unused import 'setStudentCareers' from '@/api/students'
   - Kept only 'createStudent' which is actually used

2. src/test/buildParticipants.test.ts
   - Added missing 'email' property to PersonBase objects in test data
   - Updated two test cases to include email field (required by PersonBase type)
   - Test data now properly satisfies PersonBase type requirements

Build now succeeds without errors.