### PR TITLE
feat: implement role-based router structure

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,11 +1,21 @@
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/useAuth'
+import type { Role } from '@/types/Auth'
 
-export function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth()
+interface ProtectedRouteProps {
+  children: React.ReactNode
+  allowedRoles?: Role[]
+}
+
+export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
+  const { isAuthenticated, user } = useAuth()
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />
+  }
+
+  if (allowedRoles && user && !allowedRoles.includes(user.role as Role)) {
+    return <Navigate to="/forbidden" replace />
   }
 
   return <>{children}</>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,24 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { ProjectsPage } from '@/pages/ProjectPage';
-import { ProfessorsPage } from '@/pages/ProfessorsPage';
-import { StudentsPage } from '@/pages/StudentsPage';
-import { PeoplePage } from '@/pages/PeoplePage';
-import { CareersPage } from '@/pages/CareersPage';
-import { ApplicationDomainsPage } from '@/pages/ApplicationDomainsPage';
-import { TagsPage } from '@/pages/TagsPage';
-import { LoginPage } from '@/pages/LoginPage';
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { LoginPage } from '@/pages/LoginPage'
 import { NotFoundPage, ForbiddenPage, ServerErrorPage } from '@/pages/ErrorPages'
-import { ROUTES } from '@/constants/routes';
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BackupPage } from '@/pages/BackupPage';
-import { ImportDataPage } from '@/pages/ImportDataPage';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from 'sonner'
 import { AuthProvider } from '@/contexts/AuthContext'
-import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
+import { RoleBasedRouter } from '@/router/RoleBasedRouter'
 
 const queryClient = new QueryClient()
 
@@ -26,84 +16,14 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
+        {/* Public routes */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/not-found" element={<NotFoundPage />} />
         <Route path="/forbidden" element={<ForbiddenPage />} />
         <Route path="/server-error" element={<ServerErrorPage />} />
-        <Route
-          path={ROUTES.backup}
-          element={
-            <ProtectedRoute>
-              <BackupPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.importData}
-          element={
-            <ProtectedRoute>
-              <ImportDataPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.careers}
-          element={
-            <ProtectedRoute>
-              <CareersPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.applicationDomains}
-          element={
-            <ProtectedRoute>
-              <ApplicationDomainsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.tags}
-          element={
-            <ProtectedRoute>
-              <TagsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.professors}
-          element={
-            <ProtectedRoute>
-              <ProfessorsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.students}
-          element={
-            <ProtectedRoute>
-              <StudentsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.people}
-          element={
-            <ProtectedRoute>
-              <PeoplePage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={ROUTES.projects}
-          element={
-            <ProtectedRoute>
-              <ProjectsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/" element={<Navigate to={ROUTES.projects} replace />} />
-        <Route path="*" element={<NotFoundPage />} />
+
+        {/* Protected routes - handled by RoleBasedRouter */}
+        <Route path="/*" element={<RoleBasedRouter />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/router/RoleBasedRouter.tsx
+++ b/src/router/RoleBasedRouter.tsx
@@ -1,0 +1,126 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { useAuth } from '@/contexts/useAuth'
+import { ProjectsPage } from '@/pages/ProjectPage'
+import { ProfessorsPage } from '@/pages/ProfessorsPage'
+import { StudentsPage } from '@/pages/StudentsPage'
+import { PeoplePage } from '@/pages/PeoplePage'
+import { CareersPage } from '@/pages/CareersPage'
+import { ApplicationDomainsPage } from '@/pages/ApplicationDomainsPage'
+import { TagsPage } from '@/pages/TagsPage'
+import { BackupPage } from '@/pages/BackupPage'
+import { ImportDataPage } from '@/pages/ImportDataPage'
+import { NotFoundPage, ForbiddenPage, ServerErrorPage } from '@/pages/ErrorPages'
+import { ProtectedRoute } from '@/components/ProtectedRoute'
+import type { Role } from '@/types/Auth'
+
+interface RoleRoute {
+  path: string
+  element: React.ReactNode
+  allowedRoles: Role[]
+  label: string
+}
+
+// Admin-only routes
+const adminRoutes: RoleRoute[] = [
+  {
+    path: 'projects',
+    element: <ProjectsPage />,
+    allowedRoles: ['ADMIN', 'PROFESSOR'],
+    label: 'Projects',
+  },
+  {
+    path: 'people',
+    element: <PeoplePage />,
+    allowedRoles: ['ADMIN'],
+    label: 'People',
+  },
+  {
+    path: 'professors',
+    element: <ProfessorsPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Professors',
+  },
+  {
+    path: 'students',
+    element: <StudentsPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Students',
+  },
+  {
+    path: 'careers',
+    element: <CareersPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Careers',
+  },
+  {
+    path: 'application-domains',
+    element: <ApplicationDomainsPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Application Domains',
+  },
+  {
+    path: 'tags',
+    element: <TagsPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Tags',
+  },
+  {
+    path: 'backup',
+    element: <BackupPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Backup',
+  },
+  {
+    path: 'import-data',
+    element: <ImportDataPage />,
+    allowedRoles: ['ADMIN'],
+    label: 'Import Data',
+  },
+]
+
+export function RoleBasedRouter() {
+  const { user } = useAuth()
+
+  if (!user) {
+    return (
+      <Routes>
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    )
+  }
+
+  const userRole = user.role as Role
+
+  return (
+    <Routes>
+      {/* Admin routes - filtered by role */}
+      {adminRoutes.map((route) => (
+        <Route
+          key={route.path}
+          path={route.path}
+          element={
+            route.allowedRoles.includes(userRole) ? (
+              <ProtectedRoute allowedRoles={route.allowedRoles}>{route.element}</ProtectedRoute>
+            ) : (
+              <ForbiddenPage />
+            )
+          }
+        />
+      ))}
+
+      {/* Default redirect for authenticated users */}
+      <Route path="/" element={<Navigate to="/projects" replace />} />
+
+      {/* Error pages */}
+      <Route path="/forbidden" element={<ForbiddenPage />} />
+      <Route path="/server-error" element={<ServerErrorPage />} />
+      <Route path="/not-found" element={<NotFoundPage />} />
+
+      {/* Catch all */}
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  )
+}
+
+export { adminRoutes }
+export type { RoleRoute }

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,30 +1,31 @@
-export type UserRole = 'ADMIN' | 'PROFESSOR';
+export type UserRole = 'ADMIN' | 'PROFESSOR'
+export type Role = UserRole
 
 export interface LoginRequest {
-  username: string;
-  password: string;
+  username: string
+  password: string
 }
 
 export interface LoginResponse {
-  token: string;
-  expiresAt: string;
-  role: UserRole;
-  userId: string;
-  professorId?: string;
+  token: string
+  expiresAt: string
+  role: UserRole
+  userId: string
+  professorId?: string
 }
 
 export interface AuthUser {
-  userId: string;
-  role: UserRole;
-  professorId?: string;
-  token: string;
-  expiresAt: string;
+  userId: string
+  role: UserRole
+  professorId?: string
+  token: string
+  expiresAt: string
 }
 
 export interface AuthContextType {
-  user: AuthUser | null;
-  isLoading: boolean;
-  login: (username: string, password: string) => Promise<void>;
-  logout: () => void;
-  isAuthenticated: boolean;
+  user: AuthUser | null
+  isLoading: boolean
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+  isAuthenticated: boolean
 }


### PR DESCRIPTION
Design and implementation of role-aware routing system.

Architecture:
- Single entry point at root (/)
- Routes automatically adapt based on user role
- No /admin/ prefix needed (cleaner URLs)
- Supports ADMIN and PROFESSOR roles
- Easy to extend with new roles later

Key Components Created:
- src/router/RoleBasedRouter.tsx: Main router logic
  - Routes filtered by role (ADMIN vs PROFESSOR)
  - Projects viewable by both (ADMIN sees all, PROFESSOR sees theirs)
  - Admin-only routes for people, professors, students, careers, etc.
  - Error pages for unauthenticated and unauthorized access

Updated Components:
- src/components/ProtectedRoute.tsx: Now role-aware
  - Added optional allowedRoles parameter
  - Redirects to /forbidden if user lacks permissions
  - Maintains backward compatibility

Updated Types:
- src/types/Auth.ts: Exported Role type
  - Added Role type alias for UserRole
  - Supports future role additions

Routing Flow:
1. Unauthenticated users → redirected to /login
2. Authenticated users → RoleBasedRouter checks role
3. ADMIN access → full admin panel at root (/, /projects, /people, etc.)
4. PROFESSOR access → limited to /projects (their own data)
5. Insufficient permissions → /forbidden page

Updated main.tsx:
- Simplified routing structure
- Public routes (login, error pages)
- Protected routes handled by RoleBasedRouter
- Removed manual route definitions (now in RoleBasedRouter)

Route Configuration:
Projects: ADMIN, PROFESSOR (role-based filtering server-side) People: ADMIN only
Professors: ADMIN only
Students: ADMIN only
Careers: ADMIN only
Application Domains: ADMIN only
Tags: ADMIN only
Backup: ADMIN only
Import Data: ADMIN only

Future Extensibility:
- Add PROFESSOR-specific routes (e.g., /professor/dashboard)
- Add COORDINATOR, STAFF roles
- Add role-specific sidebar/navigation logic
- Add permission caching for performance

All code TypeScript and ESLint clean. Build successful.