### PR TITLE
feat: add role translation and project detail sheet for browse projects

### DIFF
--- a/.vercel/README.txt
+++ b/.vercel/README.txt
@@ -1,0 +1,11 @@
+> Why do I have a folder named ".vercel" in my project?
+The ".vercel" folder is created when you link a directory to a Vercel project.
+
+> What does the "project.json" file contain?
+The "project.json" file contains:
+- The ID of the Vercel project that you linked ("projectId")
+- The ID of the user or team your Vercel project is owned by ("orgId")
+
+> Should I commit the ".vercel" folder?
+No, you should not share the ".vercel" folder with anyone.
+Upon creation, it will be automatically added to your ".gitignore" file.

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"prj_CFgOJQ5e5x6OVXLtSpIpdNmtM6oW","orgId":"team_9GITxZ7tdyBo2mVtiVTxjBLq","projectName":"thesisflow-fe"}

--- a/src/components/ProjectDetailDialog.tsx
+++ b/src/components/ProjectDetailDialog.tsx
@@ -1,0 +1,102 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Badge } from '@/components/ui/badge'
+import { ProjectResponse } from '@/types/ProjectResponse'
+import { getRoleDisplayName } from '@/utils/roleMapper'
+
+interface ProjectDetailDialogProps {
+  project: ProjectResponse | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ProjectDetailDialog({ project, open, onOpenChange }: ProjectDetailDialogProps) {
+  if (!project) return null
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="max-w-2xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="line-clamp-2">{project.title}</SheetTitle>
+        </SheetHeader>
+
+        <div className="space-y-6 mt-6">
+          <div className="space-y-6">
+            {/* Header Info */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Badge variant={project.type === 'THESIS' ? 'default' : 'secondary'}>
+                  {project.type === 'THESIS' ? 'Tesis' : 'TF'}
+                </Badge>
+                <span className="text-sm text-muted-foreground">{project.career.name}</span>
+                {project.initialSubmission && (
+                  <span className="text-sm text-muted-foreground">
+                    • {new Date(project.initialSubmission).getFullYear()}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Tags */}
+            {project.tags?.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="font-semibold text-sm">Etiquetas</h3>
+                <div className="flex flex-wrap gap-2">
+                  {project.tags.map((tag) => (
+                    <Badge key={tag.publicId} variant="outline">
+                      {tag.name}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Domain */}
+            {project.applicationDomain && (
+              <div className="space-y-2">
+                <h3 className="font-semibold text-sm">Dominio</h3>
+                <p className="text-sm">{project.applicationDomain.name}</p>
+                {project.applicationDomain.description && (
+                  <p className="text-xs text-muted-foreground">{project.applicationDomain.description}</p>
+                )}
+              </div>
+            )}
+
+            {/* All Participants */}
+            <div className="space-y-2">
+              <h3 className="font-semibold text-sm">Participantes</h3>
+              <div className="space-y-2">
+                {project.participants.map((p, idx) => (
+                  <div key={idx} className="flex items-center justify-between p-2 bg-muted/30 rounded">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {getRoleDisplayName(p.role)}
+                    </span>
+                    <span className="text-sm font-medium">
+                      {p.personDTO.name} {p.personDTO.lastname}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Dates */}
+            <div className="space-y-2 pt-2 border-t">
+              <h3 className="font-semibold text-sm">Fechas</h3>
+              <div className="space-y-1 text-sm">
+                <div>
+                  <span className="font-medium">Presentación:</span>{' '}
+                  {new Date(project.initialSubmission).toLocaleDateString('es-ES')}
+                </div>
+                {project.completion && (
+                  <div>
+                    <span className="font-medium">Finalización:</span>{' '}
+                    {new Date(project.completion).toLocaleDateString('es-ES')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/pages/public/BrowseProjectsPage.tsx
+++ b/src/pages/public/BrowseProjectsPage.tsx
@@ -7,12 +7,16 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { ChevronLeft, ChevronRight, Search } from 'lucide-react'
+import { ProjectDetailDialog } from '@/components/ProjectDetailDialog'
+import { getRoleDisplayName } from '@/utils/roleMapper'
+import { ProjectResponse } from '@/types/ProjectResponse'
 
 export function BrowseProjectsPage() {
   const { filters } = useAnalyticsFilters()
   const [page, setPage] = useState(0)
   const [search, setSearch] = useState('')
   const [pageSize] = useState(12)
+  const [selectedProject, setSelectedProject] = useState<ProjectResponse | null>(null)
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['browse-projects', { ...filters, search, page, size: pageSize }],
@@ -55,7 +59,11 @@ export function BrowseProjectsPage() {
           {/* Projects Grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {data.content.map((project) => (
-              <Card key={project.publicId} className="hover:shadow-lg transition-shadow">
+              <Card
+                key={project.publicId}
+                className="hover:shadow-lg transition-shadow cursor-pointer"
+                onClick={() => setSelectedProject(project)}
+              >
                 <CardHeader>
                   <div className="space-y-2">
                     <div className="flex items-start justify-between gap-2">
@@ -110,14 +118,16 @@ export function BrowseProjectsPage() {
                     <div className="space-y-1 text-xs">
                       {project.participants.slice(0, 3).map((p, idx) => (
                         <div key={idx} className="flex items-center justify-between">
-                          <span className="text-muted-foreground">{p.role}</span>
+                          <span className="text-muted-foreground">{getRoleDisplayName(p.role)}</span>
                           <span className="font-medium">
                             {p.personDTO.name} {p.personDTO.lastname}
                           </span>
                         </div>
                       ))}
                       {project.participants.length > 3 && (
-                        <div className="text-muted-foreground italic">+{project.participants.length - 3} más</div>
+                        <div className="text-muted-foreground italic cursor-pointer hover:underline" onClick={(e) => { e.stopPropagation(); setSelectedProject(project); }}>
+                          +{project.participants.length - 3} más
+                        </div>
                       )}
                     </div>
                   </div>
@@ -168,6 +178,12 @@ export function BrowseProjectsPage() {
           )}
         </>
       )}
+
+      <ProjectDetailDialog
+        project={selectedProject}
+        open={!!selectedProject}
+        onOpenChange={(open) => !open && setSelectedProject(null)}
+      />
     </div>
   )
 }

--- a/src/utils/roleMapper.ts
+++ b/src/utils/roleMapper.ts
@@ -1,0 +1,10 @@
+export const roleDisplayNames: Record<string, string> = {
+  DIRECTOR: 'Director',
+  STUDENT: 'Alumno',
+  CODIRECTOR: 'Co-director',
+  COLLABORATOR: 'Colaborador',
+}
+
+export function getRoleDisplayName(role: string): string {
+  return roleDisplayNames[role] || role
+}


### PR DESCRIPTION
- Add role display names mapping (DIRECTOR->Director, STUDENT->Alumno, CODIRECTOR->Co-director, COLLABORATOR->Colaborador)
- Create ProjectDetailDialog (Sheet) component to view full project information
- Make project cards clickable to open detail view
- Make '+n más' text clickable to view all participants in detail sheet
- Translate all role enums in browse projects view
