### PR TITLE
Allow admins to set project completion date

### DIFF
--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -45,6 +45,10 @@ export async function setProjectTags(projectPublicId: string, tagPublicIds: stri
   await api.put(`/projects/${projectPublicId}/tags`, { tags: tagPublicIds });
 }
 
+export async function setProjectCompletionDate(projectPublicId: string, completionDate: string): Promise<void> {
+  await api.put(`/projects/${projectPublicId}/completion`, { completionDate });
+}
+
 export async function deleteProject(publicId: string): Promise<void> {
   await api.delete(`/projects/${publicId}`);
 }

--- a/src/components/ProjectCompletionSheet.tsx
+++ b/src/components/ProjectCompletionSheet.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useOptionalToast } from '@/components/ui/toast'
+import { setProjectCompletionDate } from '@/api/projects'
+import { useQueryClient } from '@tanstack/react-query'
+import type { Project } from '@/types/Project'
+import { CalendarCheck2 } from 'lucide-react'
+
+interface Props {
+  project: Project | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ProjectCompletionSheet({ project, open, onOpenChange }: Props) {
+  const queryClient = useQueryClient()
+  const { push } = useOptionalToast()
+  const [completionDate, setCompletionDate] = React.useState('')
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (open && project) {
+      const current = project.completion ? project.completion.slice(0, 10) : ''
+      setCompletionDate(current)
+      setError(null)
+    }
+    if (!open) {
+      setCompletionDate('')
+      setError(null)
+    }
+  }, [open, project])
+
+  async function handleSave() {
+    if (!project) return
+    if (!completionDate) {
+      setError('Selecciona una fecha para continuar.')
+      return
+    }
+    const formatted = completionDate
+    try {
+      setSaving(true)
+      setError(null)
+      await setProjectCompletionDate(project.publicId, formatted)
+      push({
+        variant: 'success',
+        title: 'Fecha de finalización guardada',
+        message: 'La fecha de finalización se actualizó correctamente.',
+      })
+      queryClient.invalidateQueries({ queryKey: ['projects'] })
+      onOpenChange(false)
+    } catch (e: any) {
+      push({
+        variant: 'error',
+        title: 'Error al guardar',
+        message: e?.message || 'No se pudo actualizar la fecha.',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-[480px] px-6 py-6 overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Fecha de finalización</SheetTitle>
+        </SheetHeader>
+
+        {!project && (
+          <div className="mt-4 text-sm text-muted-foreground">Selecciona un proyecto para continuar.</div>
+        )}
+
+        {project && (() => {
+          const initialDate = project.initialSubmission ? project.initialSubmission.slice(0, 10) : ''
+          const currentCompletion = project.completion ? project.completion.slice(0, 10) : ''
+          const minDate = initialDate || undefined
+          return (
+          <div className="mt-6 space-y-6">
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold tracking-tight">Proyecto</h3>
+              <div className="flex items-center gap-2 rounded-md border bg-muted/60 px-3 py-2 text-sm">
+                <CalendarCheck2 className="h-4 w-4 shrink-0" />
+                <span className="line-clamp-2 font-medium">{project.title}</span>
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <h3 className="text-sm font-semibold tracking-tight">Seleccionar fecha</h3>
+                  <p className="text-xs text-muted-foreground">
+                    El proyecto se marcará como finalizado en la fecha indicada.
+                  </p>
+                </div>
+              </div>
+              <Input
+                type="date"
+                value={completionDate}
+                min={minDate}
+                onChange={(e) => {
+                  setCompletionDate(e.target.value)
+                  if (error) setError(null)
+                }}
+              />
+              {error && <p className="text-xs text-red-600">{error}</p>}
+              <div className="grid gap-1 text-xs text-muted-foreground">
+                <span>Inicio: {initialDate || '—'}</span>
+                <span>Actual: {currentCompletion || 'Sin definir'}</span>
+              </div>
+            </section>
+          </div>
+        )})()}
+
+        <SheetFooter className="mt-8 gap-2">
+          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={saving || !project}>
+            {saving ? 'Guardando…' : 'Guardar'}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/ProjectTable.tsx
+++ b/src/components/ProjectTable.tsx
@@ -1,7 +1,7 @@
 import {type Column, DataTable, type Sort} from "@/components/DataTable.tsx";
 import type {Project} from "@/types/Project.ts";
 import {Button} from "@/components/ui/button.tsx";
-import {Edit, EyeIcon, Tag as TagIcon} from "lucide-react";
+import {Edit, EyeIcon, Tag as TagIcon, CalendarCheck} from "lucide-react";
 import { ProjectManageSheet } from '@/components/ProjectManageSheet';
 import {useProjects} from "@/hooks/useProjects.ts";
 import * as React from "react";
@@ -9,6 +9,7 @@ import CreateProjectWizard from "@/components/CreateProjectWizard.tsx";
 import { useQueryClient } from '@tanstack/react-query';
 import { ProjectViewSheet } from '@/components/ProjectViewSheet';
 import { ProjectTagsSheet } from '@/components/ProjectTagsSheet';
+import { ProjectCompletionSheet } from '@/components/ProjectCompletionSheet';
 
 const TYPE_LABELS: Record<string,string> = { THESIS: 'Tesis', PROJECT: 'Proyecto Final' };
 
@@ -21,6 +22,8 @@ export default function ProjectsTable() {
 	const [viewOpen, setViewOpen] = React.useState(false);
 	const [tagsProject, setTagsProject] = React.useState<{ publicId: string; title: string; tags: Project['tags'] } | null>(null);
 	const [tagsOpen, setTagsOpen] = React.useState(false);
+	const [completionProject, setCompletionProject] = React.useState<Project | null>(null);
+	const [completionOpen, setCompletionOpen] = React.useState(false);
 	const [manageProject, setManageProject] = React.useState<Project | null>(null);
 	const [manageOpen, setManageOpen] = React.useState(false);
 	const queryClient = useQueryClient();
@@ -60,6 +63,7 @@ export default function ProjectsTable() {
 	const openView = React.useCallback((id: string) => { setViewProjectId(id); setViewOpen(true); updateUrlParam(id); }, [updateUrlParam]);
 	const handleViewOpenChange = React.useCallback((o: boolean) => { setViewOpen(o); if (!o) { setViewProjectId(null); updateUrlParam(null); } }, [updateUrlParam]);
 	const openTags = React.useCallback((p: Project) => { setTagsProject({ publicId: p.publicId, title: p.title, tags: p.tags }); setTagsOpen(true); }, []);
+	const openCompletion = React.useCallback((p: Project) => { setCompletionProject(p); setCompletionOpen(true); }, []);
 	const openManage = React.useCallback((p: Project) => { setManageProject(p); setManageOpen(true); }, []);
 
 	const columns = React.useMemo<Column<Project>[]>(() => [
@@ -123,11 +127,12 @@ export default function ProjectsTable() {
 				<div className="flex gap-2 flex-wrap">
 					<Button variant="default" size="sm" onClick={() => openView(row.publicId)} title="Ver detalles"><EyeIcon className="h-4 w-4" /></Button>
 					<Button variant="outline" size="sm" onClick={() => openTags(row)} title="Gestionar etiquetas"><TagIcon className="h-4 w-4" /></Button>
+					<Button variant="outline" size="sm" onClick={() => openCompletion(row)} title="Definir fecha de finalización"><CalendarCheck className="h-4 w-4" /></Button>
 					<Button variant="soft" size="sm" onClick={() => openManage(row)} title="Editar / Eliminar"><Edit className="h-4 w-4" /></Button>
 				</div>
 			)
 		}
-	], [openView, openTags, openManage]);
+	], [openView, openTags, openCompletion, openManage]);
 
 	const selectedProject = React.useMemo(() => {
 		return viewProjectId ? projects.find(p => p.publicId === viewProjectId) || null : null;
@@ -157,6 +162,10 @@ export default function ProjectsTable() {
 			/>
 			<ProjectViewSheet publicId={viewProjectId} open={viewOpen} onOpenChange={handleViewOpenChange} initial={selectedProject} />
 			<ProjectTagsSheet project={tagsProject} open={tagsOpen} onOpenChange={setTagsOpen} />
+			<ProjectCompletionSheet project={completionProject} open={completionOpen} onOpenChange={(open) => {
+				setCompletionOpen(open);
+				if (!open) setCompletionProject(null);
+			}} />
 			<ProjectManageSheet project={manageProject} open={manageOpen} onOpenChange={setManageOpen} onDeleted={() => {
 				setManageOpen(false); setManageProject(null); queryClient.invalidateQueries({ queryKey:['projects'] });
 			}} />


### PR DESCRIPTION
## Summary
- add project completion date sheet with date picker and project context
- call new API helper to persist completion date updates
- surface calendar action in admin project table alongside tags and edit

## Testing
- npm run lint *(fails: eslint not installed locally)*