### PR TITLE
Allow authenticated users to stay on public landing

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,6 +5,7 @@ import type {
   RequestMagicLinkRequest,
   RequestMagicLinkResponse,
   VerifyMagicLinkRequest,
+  ProfessorMagicLinkVerifyResponse,
 } from '@/types/Auth'
 
 export const authApi = {
@@ -21,8 +22,10 @@ export const authApi = {
     )
     return response.data
   },
-  verifyProfessorMagicLink: async (payload: VerifyMagicLinkRequest): Promise<LoginResponse> => {
-    const response = await api.post<LoginResponse>(
+  verifyProfessorMagicLink: async (
+    payload: VerifyMagicLinkRequest
+  ): Promise<ProfessorMagicLinkVerifyResponse> => {
+    const response = await api.post<ProfessorMagicLinkVerifyResponse>(
       '/auth/professor/verify-login-link',
       payload
     )

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   professorLogin: '/professor-login',
   professorVerify: '/professor-login/verify',
   projects: '/admin/projects',
+  professorProjects: '/admin/projects',
   people: '/admin/people',
   professors: '/admin/professors',
   students: '/admin/students',

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,24 +1,82 @@
 import React, { useState, useCallback, useEffect } from 'react'
-import type { AuthContextType, AuthUser, LoginResponse } from '@/types/Auth'
+import type {
+  AuthContextType,
+  AuthUser,
+  LoginResponse,
+  ProfessorMagicLinkVerifyResponse,
+  Role,
+} from '@/types/Auth'
 import { authApi } from '@/api/auth'
 import { AuthContext } from './AuthContextDefinition'
+
+interface PersistPayload {
+  token: string
+  expiresAt?: string
+  role?: Role
+  userId?: string
+  professorId?: string
+}
+
+function decodeJwtPayload(token: string): Record<string, any> | null {
+  try {
+    const base64Url = token.split('.')[1]
+    if (!base64Url) return null
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=')
+    const jsonPayload = atob(padded)
+    return JSON.parse(jsonPayload)
+  } catch (error) {
+    console.error('Failed to decode JWT payload', error)
+    return null
+  }
+}
+
+function isExpired(expiresAt?: string | null): boolean {
+  if (!expiresAt) return false
+  return new Date(expiresAt) <= new Date()
+}
+
+function clearStoredSession() {
+  localStorage.removeItem('authUser')
+  localStorage.removeItem('accessToken')
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(() => {
     const stored = localStorage.getItem('authUser')
-    return stored ? JSON.parse(stored) : null
+    if (!stored) return null
+    try {
+      const parsed = JSON.parse(stored) as AuthUser
+      if (isExpired(parsed?.expiresAt)) {
+        clearStoredSession()
+        return null
+      }
+      return parsed
+    } catch (error) {
+      console.warn('Invalid stored auth session', error)
+      clearStoredSession()
+      return null
+    }
   })
   const [isLoading, setIsLoading] = useState(false)
 
-  const persistSession = useCallback((response: LoginResponse) => {
+  const persistSession = useCallback((payload: PersistPayload) => {
+    const decoded = decodeJwtPayload(payload.token)
+    const derivedRole = (payload.role || decoded?.role || decoded?.authorities?.[0]) as Role | undefined
+    const derivedUserId = payload.userId || decoded?.userId || decoded?.sub || decoded?.id
+    const derivedProfessorId = payload.professorId || decoded?.professorId
+    const expiresAt =
+      payload.expiresAt || (decoded?.exp ? new Date(decoded.exp * 1000).toISOString() : null)
+
     const authUser: AuthUser = {
-      userId: response.userId,
-      role: response.role,
-      professorId: response.professorId,
-      token: response.token,
-      expiresAt: response.expiresAt,
+      userId: derivedUserId ?? '',
+      role: (derivedRole ?? 'PROFESSOR') as Role,
+      professorId: derivedProfessorId,
+      token: payload.token,
+      expiresAt: expiresAt ?? new Date(Date.now() + 60 * 60 * 1000).toISOString(),
     }
-    localStorage.setItem('accessToken', response.token)
+
+    localStorage.setItem('accessToken', payload.token)
     localStorage.setItem('authUser', JSON.stringify(authUser))
     setUser(authUser)
   }, [])
@@ -27,7 +85,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(true)
     try {
       const response = await authApi.login({ username, password })
-      persistSession(response)
+      persistSession({
+        token: response.token,
+        expiresAt: response.expiresAt,
+        role: response.role,
+        userId: response.userId,
+        professorId: response.professorId,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -45,27 +109,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const verifyProfessorMagicLink = useCallback(async (token: string) => {
     setIsLoading(true)
     try {
-      const response = await authApi.verifyProfessorMagicLink({ token })
-      persistSession(response)
+      const response: ProfessorMagicLinkVerifyResponse = await authApi.verifyProfessorMagicLink({ token })
+      persistSession({ token: response.accessToken })
+      return response.redirectUrl ?? '/'
     } finally {
       setIsLoading(false)
     }
   }, [persistSession])
 
   const logout = useCallback(() => {
-    localStorage.removeItem('accessToken')
-    localStorage.removeItem('authUser')
+    clearStoredSession()
     setUser(null)
   }, [])
 
-  // Check if token has expired
   useEffect(() => {
-    if (user) {
-      const expiresAt = new Date(user.expiresAt)
-      const now = new Date()
-      if (now >= expiresAt) {
-        logout()
-      }
+    if (user && isExpired(user.expiresAt)) {
+      logout()
     }
   }, [user, logout])
 

--- a/src/pages/ProfessorLoginVerifyPage.tsx
+++ b/src/pages/ProfessorLoginVerifyPage.tsx
@@ -32,11 +32,12 @@ export function ProfessorLoginVerifyPage() {
     setStatus('loading')
 
     verifyProfessorMagicLink(token)
-      .then(() => {
+      .then((redirectUrl) => {
         if (!isMounted) return
         setStatus('success')
         setTimeout(() => {
-          navigate('/admin/projects', { replace: true })
+          const target = redirectUrl || ROUTES.projects
+          navigate(target, { replace: true })
         }, 1000)
       })
       .catch((err: unknown) => {

--- a/src/pages/public/PublicLayout.tsx
+++ b/src/pages/public/PublicLayout.tsx
@@ -1,12 +1,13 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { BarChart3, Folder, LogIn } from 'lucide-react'
+import { BarChart3, Folder, LogIn, LogOut, UserCircle2 } from 'lucide-react'
 import { useAuth } from '@/contexts/useAuth'
+import { ROUTES } from '@/constants/routes'
 
 export function PublicLayout({ children }: { children: React.ReactNode }) {
   const location = useLocation()
   const navigate = useNavigate()
-  const { logout } = useAuth()
+  const { logout, user } = useAuth()
 
   const isOnProjects = location.pathname === '/projects'
   const isOnAnalytics = location.pathname === '/analytics'
@@ -15,6 +16,8 @@ export function PublicLayout({ children }: { children: React.ReactNode }) {
     logout()
     navigate('/')
   }
+
+  const dashboardPath = user?.role === 'PROFESSOR' ? ROUTES.professorProjects : ROUTES.projects
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -53,14 +56,37 @@ export function PublicLayout({ children }: { children: React.ReactNode }) {
               </Button>
 
               <div className="ml-4 border-l border-slate-200 pl-4">
-                <Button
-                  onClick={() => navigate('/login')}
-                  size="sm"
-                  className="flex items-center gap-2"
-                >
-                  <LogIn className="h-4 w-4" />
-                  Iniciar Sesión
-                </Button>
+                {!user ? (
+                  <Button
+                    onClick={() => navigate('/login')}
+                    size="sm"
+                    className="flex items-center gap-2"
+                  >
+                    <LogIn className="h-4 w-4" />
+                    Iniciar Sesión
+                  </Button>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex items-center gap-2"
+                      onClick={() => navigate(dashboardPath)}
+                    >
+                      <UserCircle2 className="h-4 w-4" />
+                      {user.role === 'PROFESSOR' ? 'Ver mis proyectos' : 'Panel administrador'}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="flex items-center gap-2"
+                      onClick={handleLogout}
+                    >
+                      <LogOut className="h-4 w-4" />
+                      Cerrar sesión
+                    </Button>
+                  </div>
+                )}
               </div>
             </nav>
           </div>

--- a/src/pages/public/PublicRouter.tsx
+++ b/src/pages/public/PublicRouter.tsx
@@ -4,17 +4,7 @@ import { PublicHomePage } from '@/pages/public/PublicHomePage'
 import { BrowseProjectsPage } from '@/pages/public/BrowseProjectsPage'
 import { AnalyticsDashboardPage } from '@/pages/public/AnalyticsDashboardPage'
 import { AnalyticsProvider } from '@/pages/public/AnalyticsContext'
-import { RoleBasedRouter } from '@/router/RoleBasedRouter'
-import { useAuth } from '@/contexts/useAuth'
-
 export function PublicRouter() {
-  const { user } = useAuth()
-
-  // If authenticated, redirect to admin area
-  if (user) {
-    return <RoleBasedRouter />
-  }
-
   return (
     <PublicLayout>
       <Routes>

--- a/src/router/RoleBasedRouter.tsx
+++ b/src/router/RoleBasedRouter.tsx
@@ -95,7 +95,7 @@ export function RoleBasedRouter() {
 
   const redirectPath = useMemo(() => {
     if (userRole === 'PROFESSOR') {
-      return ROUTES.projects
+      return ROUTES.professorProjects
     }
     return ROUTES.projects
   }, [userRole])
@@ -127,9 +127,9 @@ export function RoleBasedRouter() {
       <Route index element={<Navigate to={redirectPath} replace />} />
 
       {/* Error pages */}
-      <Route path="/forbidden" element={<ForbiddenPage />} />
-      <Route path="/server-error" element={<ServerErrorPage />} />
-      <Route path="/not-found" element={<NotFoundPage />} />
+      <Route path="forbidden" element={<ForbiddenPage />} />
+      <Route path="server-error" element={<ServerErrorPage />} />
+      <Route path="not-found" element={<NotFoundPage />} />
 
       {/* Catch all */}
       <Route path="*" element={<NotFoundPage />} />

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -26,6 +26,11 @@ export interface LoginResponse {
   professorId?: string
 }
 
+export interface ProfessorMagicLinkVerifyResponse {
+  accessToken: string
+  redirectUrl?: string
+}
+
 export interface AuthUser {
   userId: string
   role: UserRole
@@ -39,7 +44,7 @@ export interface AuthContextType {
   isLoading: boolean
   login: (username: string, password: string) => Promise<void>
   requestProfessorMagicLink: (email: string) => Promise<void>
-  verifyProfessorMagicLink: (token: string) => Promise<void>
+  verifyProfessorMagicLink: (token: string) => Promise<string>
   logout: () => void
   isAuthenticated: boolean
 }


### PR DESCRIPTION
## Summary
- keep public landing accessible regardless of session state and show role-specific actions when logged in
- persist professor sessions from magic-link tokens and respect backend redirect destinations
- normalize admin routing so admins and professors land on the right dashboard without forcing /admin/projects

## Testing
- npm run lint *(fails: eslint not installed locally)*