### PR TITLE
Tighten admin table layouts

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -179,18 +179,22 @@ export function DataTable<T>({
         <Table>
           <TableHeader>
             <TableRow>
-              {columns.map(col => {
-                // ...existing code for sort header...
+              {columns.map((col, idx) => {
                 const sortable = !!col.sortField;
                 const active = sortable && sort.field === col.sortField;
+                const isActions = idx === columns.length - 1;
                 return (
                   <TableHead
                     key={col.id}
                     style={col.width ? { width: col.width } : undefined}
-                    className={[col.className ?? "", sortable ? "cursor-pointer select-none" : ""].join(" ")}
+                    className={[
+                      col.className ?? "",
+                      sortable ? "cursor-pointer select-none" : "",
+                      isActions ? "text-right" : ""
+                    ].join(" ")}
                     onClick={sortable ? () => toggleSort(col.sortField!) : undefined}
                   >
-                    <div className="flex items-center gap-1">
+                    <div className={["flex items-center gap-1", isActions ? "justify-end" : ""].join(" ")}>
                       <span>{col.header}</span>
                       {sortable && (
                         <span className="inline-flex items-center">
@@ -208,14 +212,19 @@ export function DataTable<T>({
             </TableRow>
             {hasFilters && (
               <TableRow>
-                {columns.map(col => {
+                {columns.map((col, idx) => {
                   if (!col.sortField) return <TableHead key={col.id} style={col.width ? { width: col.width } : undefined} />;
                   const conf = col.filter || {};
                   const type = conf.type || 'text';
                   const appliedVal = filters[col.sortField];
                   const selectValue = appliedVal ?? CLEAR_SELECT_VALUE;
+                  const isActions = idx === columns.length - 1;
                   return (
-                    <TableHead key={col.id} style={col.width ? { width: col.width } : undefined}>
+                    <TableHead
+                      key={col.id}
+                      style={col.width ? { width: col.width } : undefined}
+                      className={[col.className ?? '', isActions ? 'text-right' : ''].join(' ').trim() || undefined}
+                    >
                       {type === 'select' && conf.options ? (
                         <Select
                           value={selectValue}
@@ -238,7 +247,7 @@ export function DataTable<T>({
                           </SelectContent>
                         </Select>
                       ) : (
-                        <div className="relative">
+                        <div className={["relative", isActions ? "ml-auto" : ""].join(" ")}>
                           <Input
                             ref={assignTextRef}
                             value={inputFilters[col.sortField] ?? ''}
@@ -281,8 +290,13 @@ export function DataTable<T>({
             )}
             {!loading && !error && rows.map((row, i) => (
               <TableRow key={i}>
-                {columns.map(col => (
-                  <TableCell key={col.id} className={col.className}>{col.accessor(row)}</TableCell>
+                {columns.map((col, idx) => (
+                  <TableCell
+                    key={col.id}
+                    className={[col.className ?? '', idx === columns.length - 1 ? 'text-right' : ''].join(' ').trim() || undefined}
+                  >
+                    {col.accessor(row)}
+                  </TableCell>
                 ))}
               </TableRow>
             ))}

--- a/src/components/ProjectTable.tsx
+++ b/src/components/ProjectTable.tsx
@@ -70,8 +70,13 @@ export default function ProjectsTable() {
 		{
 			id: "title",
 			header: "Título",
-			accessor: (row) => row.title,
+			accessor: (row) => (
+				<div className="font-medium leading-snug whitespace-normal">
+					{row.title}
+				</div>
+			),
 			sortField: "title",
+			className: "max-w-[320px] whitespace-normal",
 			filter: { type: 'text', placeholder: 'Buscar título' }
 		},
 		{
@@ -79,6 +84,7 @@ export default function ProjectsTable() {
 			header: "Tipo",
 			accessor: (row) => TYPE_LABELS[row.type] || row.type,
 			sortField: "type",
+			className: "whitespace-nowrap",
 			filter: { type: 'select', placeholder: 'Todos', options: [
 				{ value: 'THESIS', label: TYPE_LABELS.THESIS },
 				{ value: 'PROJECT', label: TYPE_LABELS.PROJECT },
@@ -87,27 +93,61 @@ export default function ProjectsTable() {
 		{
 			id: "career",
 			header: "Carrera",
-			accessor: (row) => row.career?.name || '-',
+			accessor: (row) => (
+				<div className="whitespace-normal leading-snug text-sm">
+					{row.career?.name || '-'}
+				</div>
+			),
 			sortField: "career",
+			className: "max-w-[220px] whitespace-normal",
 			filter: { type: 'text', placeholder: 'Filtrar carrera' }
 		},
 		{
 			id: "subtypes",
 			header: "Subtipos",
-			accessor: (row) => row.subtypes?.join(", "),
+			accessor: (row) => (
+				<div className="whitespace-normal text-xs text-muted-foreground">
+					{row.subtypes && row.subtypes.length > 0 ? row.subtypes.join(', ') : '—'}
+				</div>
+			),
+			className: "max-w-[220px] whitespace-normal",
 		},
 		{
 			id: "directors",
 			header: "Directores",
-			accessor: (row) => row.directors.map(s => `${s.lastname}, ${s.name}`).sort().join("\n"),
+			accessor: (row) => (
+				<div className="whitespace-normal text-sm leading-snug">
+					{row.directors.length === 0
+						? <span className="text-muted-foreground">—</span>
+						: row.directors
+							.map(s => `${s.lastname}, ${s.name}`)
+							.sort()
+							.map((name) => (
+								<div key={name}>{name}</div>
+							))}
+				</div>
+			),
 			sortField: "directors",
+			className: "max-w-[240px] whitespace-normal",
 			filter: { type: 'text', placeholder: 'Filtrar director' }
 		},
 		{
 			id: "students",
 			header: "Alumnos",
-			accessor: (row) => row.students.map(s => `${s.lastname}, ${s.name}`).sort().join("\n"),
+			accessor: (row) => (
+				<div className="whitespace-normal text-sm leading-snug">
+					{row.students.length === 0
+						? <span className="text-muted-foreground">—</span>
+						: row.students
+							.map(s => `${s.lastname}, ${s.name}`)
+							.sort()
+							.map((name) => (
+								<div key={name}>{name}</div>
+							))}
+				</div>
+			),
 			sortField: "students",
+			className: "max-w-[240px] whitespace-normal",
 			filter: { type: 'text', placeholder: 'Filtrar alumno' }
 		},
 		{
@@ -115,6 +155,7 @@ export default function ProjectsTable() {
 			header: "Estado",
 			accessor: (row) => row.completion ? "Finalizado" : "En curso",
 			sortField: "completion", // enable filter
+			className: "whitespace-nowrap text-center",
 			filter: { type: 'select', placeholder: 'Todos', options: [
 				{ value: 'true', label: 'Finalizado' },
 				{ value: 'false', label: 'En curso' },
@@ -124,13 +165,14 @@ export default function ProjectsTable() {
 			id: "actions",
 			header: "Acciones",
 			accessor: (row) => (
-				<div className="flex gap-2 flex-wrap">
+				<div className="flex gap-2 justify-end">
 					<Button variant="default" size="sm" onClick={() => openView(row.publicId)} title="Ver detalles"><EyeIcon className="h-4 w-4" /></Button>
 					<Button variant="outline" size="sm" onClick={() => openTags(row)} title="Gestionar etiquetas"><TagIcon className="h-4 w-4" /></Button>
 					<Button variant="outline" size="sm" onClick={() => openCompletion(row)} title="Definir fecha de finalización"><CalendarCheck className="h-4 w-4" /></Button>
 					<Button variant="soft" size="sm" onClick={() => openManage(row)} title="Editar / Eliminar"><Edit className="h-4 w-4" /></Button>
 				</div>
-			)
+			),
+			className: "whitespace-nowrap text-right"
 		}
 	], [openView, openTags, openCompletion, openManage]);
 

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-top [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- let table cells wrap and right-align action columns to keep buttons on one row
- trim project table column widths and typography so content stays within the viewport

## Testing
- npm run build