### PR TITLE
fix: move 'Agregar recurso' button to top of edit form for visibility

### DIFF
--- a/src/api/projectResources.ts
+++ b/src/api/projectResources.ts
@@ -1,3 +1,4 @@
+import { api } from '@/api/axios';
 import type { ProjectResourceRequest } from '@/types/ProjectResource';
 import type { ProjectResponse } from '@/types/ProjectResponse';
 
@@ -5,18 +6,6 @@ export async function updateProjectResources(
   projectId: string,
   resources: ProjectResourceRequest[]
 ): Promise<ProjectResponse> {
-  const response = await fetch(`/projects/${projectId}/resources`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(resources),
-  });
-
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.message || 'Failed to update resources');
-  }
-
-  return response.json();
+  const { data } = await api.put<ProjectResponse>(`/projects/${projectId}/resources`, resources);
+  return data;
 }

--- a/src/api/projectResources.ts
+++ b/src/api/projectResources.ts
@@ -5,7 +5,7 @@ export async function updateProjectResources(
   projectId: string,
   resources: ProjectResourceRequest[]
 ): Promise<ProjectResponse> {
-  const response = await fetch(`/api/projects/${projectId}/resources`, {
+  const response = await fetch(`/projects/${projectId}/resources`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -15,64 +15,77 @@ interface Props {
 }
 
 export function ProjectResourcesPanel({ projectId, resources = [], canEdit = false }: Props) {
-  const [isEditing, setIsEditing] = React.useState(false);
-  const [items, setItems] = React.useState<ProjectResourceRequest[]>(resources);
+  const [formItems, setFormItems] = React.useState<ProjectResourceRequest[]>(resources);
   const [isSaving, setIsSaving] = React.useState(false);
+  const [isEditing, setIsEditing] = React.useState(false);
   const { push } = useOptionalToast();
   const queryClient = useQueryClient();
 
-  React.useEffect(() => {
-    setItems(resources);
-  }, [resources]);
-
-  function addResource() {
-    setItems([...items, { url: '', title: '', description: '' }]);
+  function addNewResource() {
+    setFormItems([...formItems, { url: '', title: '', description: '' }]);
   }
 
-  function updateResource(index: number, field: keyof ProjectResourceRequest, value: string) {
-    const updated = [...items];
+  function removeResourceItem(index: number) {
+    setFormItems(formItems.filter((_, i) => i !== index));
+  }
+
+  function updateResourceItem(index: number, field: keyof ProjectResourceRequest, value: string) {
+    const updated = [...formItems];
     updated[index] = { ...updated[index], [field]: value };
-    setItems(updated);
+    setFormItems(updated);
   }
 
-  function removeResource(index: number) {
-    setItems(items.filter((_, i) => i !== index));
-  }
-
-  function cancel() {
-    setItems(resources);
+  function handleCancel() {
+    setFormItems(resources);
     setIsEditing(false);
   }
 
-  async function save() {
-    // Validate
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (!item.url || !item.title) {
-        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: URL y Título son requeridos` });
+  function isValidUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleSave() {
+    // Validate all items
+    for (let i = 0; i < formItems.length; i++) {
+      const item = formItems[i];
+      
+      if (!item.url.trim()) {
+        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: URL es requerida` });
         return;
       }
+      
       if (!isValidUrl(item.url)) {
-        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: URL inválida` });
+        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: URL inválida (debe ser HTTP/HTTPS)` });
         return;
       }
+      
+      if (!item.title.trim()) {
+        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: Título es requerido` });
+        return;
+      }
+      
       if (item.title.length > 255) {
-        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: Título muy largo (máx 255 caracteres)` });
+        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: Título muy largo (máx 255)` });
         return;
       }
+      
       if (item.description && item.description.length > 1000) {
-        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: Descripción muy larga (máx 1000 caracteres)` });
+        push({ variant: 'error', title: 'Error', message: `Recurso ${i + 1}: Descripción muy larga (máx 1000)` });
         return;
       }
     }
 
     setIsSaving(true);
     try {
-      await updateProjectResources(projectId, items);
-      // Invalidate project query
+      await updateProjectResources(projectId, formItems);
       await queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setIsEditing(false);
-      push({ variant: 'success', title: 'Éxito', message: 'Recursos actualizados' });
+      push({ variant: 'success', title: 'Éxito', message: 'Recursos guardados' });
     } catch (error) {
       push({ variant: 'error', title: 'Error', message: (error as Error).message });
     } finally {
@@ -80,168 +93,162 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
     }
   }
 
+  if (!isEditing) {
+    // View mode
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold tracking-tight">Recursos</h3>
+          {canEdit && (
+            <Button 
+              size="sm" 
+              variant="outline" 
+              onClick={() => setIsEditing(true)}
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Editar
+            </Button>
+          )}
+        </div>
+
+        {formItems.length === 0 ? (
+          <div className="text-xs text-muted-foreground py-3 px-3 bg-muted/30 rounded border border-dashed">
+            Sin recursos
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {formItems.map((resource, idx) => (
+              <div key={idx} className="border rounded-md p-3 space-y-2 hover:bg-muted/30 transition-colors">
+                <a
+                  href={resource.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                >
+                  {resource.title}
+                  <ExternalLink className="h-3.5 w-3.5 flex-shrink-0" />
+                </a>
+                <p className="text-xs text-muted-foreground break-all">{resource.url}</p>
+                {resource.description && (
+                  <p className="text-xs text-muted-foreground">{resource.description}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Edit mode
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="text-base font-semibold tracking-tight">Recursos</h3>
-        {canEdit && (
-          <Button 
-            size="sm" 
-            variant={isEditing ? "default" : "outline"} 
-            onClick={() => setIsEditing(!isEditing)}
-          >
-            <Plus className="h-4 w-4 mr-1" /> 
-            {isEditing ? 'Listo' : 'Editar'}
-          </Button>
-        )}
+        <Button 
+          size="sm" 
+          variant="default" 
+          onClick={() => setIsEditing(false)}
+        >
+          Listo
+        </Button>
       </div>
 
-      {!isEditing ? (
-        // View mode
-        <div className="space-y-3">
-          {items.length === 0 ? (
-            <div className="text-xs text-muted-foreground py-4 px-3 bg-muted/30 rounded border border-dashed">
-              Sin recursos
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {items.map((resource, idx) => (
-                <div
-                  key={idx}
-                  className="border rounded-md p-3 space-y-2 hover:bg-muted/30 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <a
-                        href={resource.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-sm font-medium text-primary hover:underline break-words"
-                      >
-                        {resource.title}
-                        <ExternalLink className="h-3.5 w-3.5 flex-shrink-0" />
-                      </a>
-                      <p className="text-xs text-muted-foreground mt-1 break-all">{resource.url}</p>
-                    </div>
-                  </div>
-                  {resource.description && (
-                    <p className="text-xs text-muted-foreground leading-relaxed">{resource.description}</p>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      ) : (
-        // Edit mode
-        <div className="space-y-4 border rounded-md p-4 bg-muted/30">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addResource}
-            className="w-full"
-            disabled={isSaving}
-          >
-            <Plus className="h-4 w-4 mr-1" /> Agregar recurso
-          </Button>
+      <div className="border rounded-md p-4 bg-muted/30 space-y-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addNewResource}
+          className="w-full"
+          disabled={isSaving}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Agregar Recurso
+        </Button>
 
+        {formItems.length === 0 ? (
+          <div className="text-xs text-muted-foreground text-center py-6">
+            No hay recursos. Haz clic arriba para agregar uno.
+          </div>
+        ) : (
           <div className="space-y-3">
-            {items.length === 0 && (
-              <div className="text-xs text-muted-foreground text-center py-4">Sin recursos. Agrega uno arriba.</div>
-            )}
-            {items.map((resource, idx) => (
-              <div key={idx} className="space-y-3 border rounded p-3 bg-white">
-                <div className="flex items-center justify-between mb-2">
+            {formItems.map((resource, idx) => (
+              <div key={idx} className="bg-white border rounded-md p-3 space-y-3">
+                <div className="flex items-center justify-between">
                   <span className="text-xs font-semibold text-muted-foreground">Recurso {idx + 1}</span>
                   <button
                     type="button"
-                    onClick={() => removeResource(idx)}
-                    className="text-destructive hover:text-destructive/70"
-                    title="Eliminar recurso"
+                    onClick={() => removeResourceItem(idx)}
+                    className="text-red-600 hover:text-red-700 p-1"
+                    title="Eliminar"
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>
                 </div>
 
                 <div>
-                  <label className="text-xs font-medium">URL *</label>
+                  <label className="text-xs font-medium block mb-1">URL *</label>
                   <Input
                     type="url"
-                    placeholder="https://..."
+                    placeholder="https://ejemplo.com/archivo"
                     value={resource.url}
-                    onChange={(e) => updateResource(idx, 'url', e.target.value)}
-                    className="mt-1 h-8"
+                    onChange={(e) => updateResourceItem(idx, 'url', e.target.value)}
+                    className="h-8 text-sm"
                   />
                 </div>
 
                 <div>
-                  <div className="flex justify-between items-center">
+                  <div className="flex justify-between mb-1">
                     <label className="text-xs font-medium">Título *</label>
-                    <span className="text-xs text-muted-foreground">
-                      {resource.title.length}/255
-                    </span>
+                    <span className="text-xs text-muted-foreground">{resource.title.length}/255</span>
                   </div>
                   <Input
                     placeholder="Nombre del archivo"
                     value={resource.title}
-                    onChange={(e) => updateResource(idx, 'title', e.target.value.slice(0, 255))}
-                    maxLength={255}
-                    className="mt-1 h-8"
+                    onChange={(e) => updateResourceItem(idx, 'title', e.target.value.slice(0, 255))}
+                    className="h-8 text-sm"
                   />
                 </div>
 
                 <div>
-                  <div className="flex justify-between items-center">
+                  <div className="flex justify-between mb-1">
                     <label className="text-xs font-medium">Descripción</label>
-                    <span className="text-xs text-muted-foreground">
-                      {(resource.description?.length || 0)}/1000
-                    </span>
+                    <span className="text-xs text-muted-foreground">{(resource.description?.length || 0)}/1000</span>
                   </div>
                   <textarea
-                    placeholder="Detalles sobre el recurso (opcional)"
+                    placeholder="Descripción opcional"
                     value={resource.description || ''}
-                    onChange={(e) => updateResource(idx, 'description', e.target.value.slice(0, 1000))}
-                    maxLength={1000}
-                    className="mt-1 w-full px-3 py-2 border rounded text-xs resize-none"
-                    rows={2}
+                    onChange={(e) => updateResourceItem(idx, 'description', e.target.value.slice(0, 1000))}
+                    className="w-full h-16 p-2 border rounded text-sm resize-none"
                   />
                 </div>
               </div>
             ))}
           </div>
+        )}
+      </div>
 
-          <Separator />
+      <Separator />
 
-          <div className="flex gap-2 justify-end">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={cancel}
-              disabled={isSaving}
-            >
-              Cancelar
-            </Button>
-            <Button
-              size="sm"
-              onClick={save}
-              disabled={isSaving}
-            >
-              {isSaving && <Loader className="h-4 w-4 mr-1 animate-spin" />}
-              {isSaving ? 'Guardando...' : 'Guardar'}
-            </Button>
-          </div>
-        </div>
-      )}
+      <div className="flex gap-2 justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCancel}
+          disabled={isSaving}
+        >
+          Cancelar
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving && <Loader className="h-4 w-4 mr-1 animate-spin" />}
+          {isSaving ? 'Guardando...' : 'Guardar'}
+        </Button>
+      </div>
     </div>
   );
-}
-
-function isValidUrl(url: string): boolean {
-  try {
-    const u = new URL(url);
-    return u.protocol === 'http:' || u.protocol === 'https:';
-  } catch {
-    return false;
-  }
 }

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -243,14 +243,20 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
         <Button
           variant="outline"
           size="sm"
-          onClick={handleCancel}
+          onClick={() => {
+            console.log('Cancelar clicked');
+            handleCancel();
+          }}
           disabled={isSaving}
         >
           Cancelar
         </Button>
         <Button
           size="sm"
-          onClick={handleSave}
+          onClick={() => {
+            console.log('Guardar clicked, about to call handleSave');
+            handleSave();
+          }}
           disabled={isSaving}
         >
           {isSaving && <Loader className="h-4 w-4 mr-1 animate-spin" />}

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -21,6 +21,10 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
   const { push } = useOptionalToast();
   const queryClient = useQueryClient();
 
+  React.useEffect(() => {
+    setFormItems(resources);
+  }, [resources]);
+
   function addNewResource() {
     setFormItems([...formItems, { url: '', title: '', description: '' }]);
   }
@@ -50,7 +54,8 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
   }
 
   async function handleSave() {
-    // Validate all items
+    // Allow saving empty resources list (to delete all)
+    // But validate any items that exist
     for (let i = 0; i < formItems.length; i++) {
       const item = formItems[i];
       
@@ -85,9 +90,10 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
       await updateProjectResources(projectId, formItems);
       await queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setIsEditing(false);
-      push({ variant: 'success', title: 'Éxito', message: 'Recursos guardados' });
+      push({ variant: 'success', title: 'Éxito', message: 'Recursos guardados correctamente' });
     } catch (error) {
-      push({ variant: 'error', title: 'Error', message: (error as Error).message });
+      const errorMsg = error instanceof Error ? error.message : 'Error desconocido';
+      push({ variant: 'error', title: 'Error al guardar', message: errorMsg });
     } finally {
       setIsSaving(false);
     }

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -135,9 +135,20 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
       ) : (
         // Edit mode
         <div className="space-y-4 border rounded-md p-4 bg-muted/30">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addResource}
+            className="w-full"
+            disabled={isSaving}
+          >
+            <Plus className="h-4 w-4 mr-1" /> Agregar recurso
+          </Button>
+
           <div className="space-y-3">
             {items.length === 0 && (
-              <div className="text-xs text-muted-foreground text-center py-4">Sin recursos. Agrega uno debajo.</div>
+              <div className="text-xs text-muted-foreground text-center py-4">Sin recursos. Agrega uno arriba.</div>
             )}
             {items.map((resource, idx) => (
               <div key={idx} className="space-y-3 border rounded p-3 bg-white">
@@ -199,17 +210,6 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
               </div>
             ))}
           </div>
-
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={addResource}
-            className="w-full"
-            disabled={isSaving}
-          >
-            <Plus className="h-4 w-4 mr-1" /> Agregar recurso
-          </Button>
 
           <Separator />
 

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -15,15 +15,11 @@ interface Props {
 }
 
 export function ProjectResourcesPanel({ projectId, resources = [], canEdit = false }: Props) {
-  const [formItems, setFormItems] = React.useState<ProjectResourceRequest[]>(resources);
+  const [formItems, setFormItems] = React.useState<ProjectResourceRequest[]>(() => resources);
   const [isSaving, setIsSaving] = React.useState(false);
   const [isEditing, setIsEditing] = React.useState(false);
   const { push } = useOptionalToast();
   const queryClient = useQueryClient();
-
-  React.useEffect(() => {
-    setFormItems(resources);
-  }, [resources]);
 
   function addNewResource() {
     setFormItems([...formItems, { url: '', title: '', description: '' }]);

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -50,6 +50,8 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
   }
 
   async function handleSave() {
+    console.log('handleSave called with formItems:', formItems);
+    
     // Allow saving empty resources list (to delete all)
     // But validate any items that exist
     for (let i = 0; i < formItems.length; i++) {
@@ -83,11 +85,15 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
 
     setIsSaving(true);
     try {
-      await updateProjectResources(projectId, formItems);
+      console.log('Calling updateProjectResources with:', { projectId, formItems });
+      const result = await updateProjectResources(projectId, formItems);
+      console.log('API Response:', result);
+      
       await queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setIsEditing(false);
       push({ variant: 'success', title: 'Éxito', message: 'Recursos guardados correctamente' });
     } catch (error) {
+      console.error('Error saving resources:', error);
       const errorMsg = error instanceof Error ? error.message : 'Error desconocido';
       push({ variant: 'error', title: 'Error al guardar', message: errorMsg });
     } finally {

--- a/src/components/ProjectResourcesPanel.tsx
+++ b/src/components/ProjectResourcesPanel.tsx
@@ -50,8 +50,6 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
   }
 
   async function handleSave() {
-    console.log('handleSave called with formItems:', formItems);
-    
     // Allow saving empty resources list (to delete all)
     // But validate any items that exist
     for (let i = 0; i < formItems.length; i++) {
@@ -85,15 +83,11 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
 
     setIsSaving(true);
     try {
-      console.log('Calling updateProjectResources with:', { projectId, formItems });
-      const result = await updateProjectResources(projectId, formItems);
-      console.log('API Response:', result);
-      
+      await updateProjectResources(projectId, formItems);
       await queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setIsEditing(false);
       push({ variant: 'success', title: 'Éxito', message: 'Recursos guardados correctamente' });
     } catch (error) {
-      console.error('Error saving resources:', error);
       const errorMsg = error instanceof Error ? error.message : 'Error desconocido';
       push({ variant: 'error', title: 'Error al guardar', message: errorMsg });
     } finally {
@@ -243,20 +237,14 @@ export function ProjectResourcesPanel({ projectId, resources = [], canEdit = fal
         <Button
           variant="outline"
           size="sm"
-          onClick={() => {
-            console.log('Cancelar clicked');
-            handleCancel();
-          }}
+          onClick={handleCancel}
           disabled={isSaving}
         >
           Cancelar
         </Button>
         <Button
           size="sm"
-          onClick={() => {
-            console.log('Guardar clicked, about to call handleSave');
-            handleSave();
-          }}
+          onClick={handleSave}
           disabled={isSaving}
         >
           {isSaving && <Loader className="h-4 w-4 mr-1 animate-spin" />}


### PR DESCRIPTION
- Move 'Agregar recurso' button to top of edit panel (below toggle button)
- Fixes issue where button was hidden at bottom of form
- Users can now easily see and click the button immediately when entering edit mode
- Update empty state message to 'Agrega uno arriba'
- Better UX flow for adding resources
