### PR TITLE
Fix: handle undefined entityName in slugify function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 // Utility: create a lowercase, hyphen-separated slug from a string (remove diacritics)
-export function slugify(value: string): string {
+export function slugify(value: string | undefined | null): string {
+  if (!value) return "";
   return value
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "") // remove diacritics


### PR DESCRIPTION
Fixes TypeError when navigating to professors page

## Problem
TypeError: Cannot read properties of undefined (reading 'normalize')

## Solution
- Add defensive check to slugify() to handle undefined/null values
- Returns empty string for falsy values instead of crashing
- Prevents error when entityName is undefined in ConfirmDeleteDialog