### PR TITLE
fix: use raw date strings instead of parsing

### DIFF
--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a date string (YYYY-MM-DD) to Spanish locale format without parsing.
+ * Avoids timezone offset issues by treating the string directly.
+ * 
+ * @param dateString - ISO date string (e.g., "2023-12-25")
+ * @returns Formatted date string (e.g., "25/12/2023")
+ */
+export function formatToLocaleDateString(dateString: string): string {
+  const [year, month, day] = dateString.split('-');
+  return `${day}/${month}/${year}`;
+}
+
+/**
+ * Get the year from a date string (YYYY-MM-DD).
+ * 
+ * @param dateString - ISO date string (e.g., "2023-12-25")
+ * @returns Year as number
+ */
+export function getYear(dateString: string): number {
+  return parseInt(dateString.split('-')[0], 10);
+}


### PR DESCRIPTION
## Problem
LocalDate values from the backend were being parsed with JavaScript's Date constructor, which interprets them according to the client's timezone, causing date mismatches (e.g., showing 18 instead of 19).

## Solution
Created simple string manipulation utilities that work directly with ISO format dates (YYYY-MM-DD) without any parsing or timezone conversion:

- `formatToLocaleDateString('2024-12-19')` → `'19/12/2024'`
- `getYear('2024-12-19')` → `2024`

## Files Changed
- Created `src/lib/dateUtils.ts` with timezone-safe date utilities
- Updated date displays across the app to use the new utilities

## Testing
✅ Dates now display consistently regardless of client timezone