### PR TITLE
fix: use raw date strings instead of parsing

### DIFF
--- a/src/components/ProjectDetailDialog.tsx
+++ b/src/components/ProjectDetailDialog.tsx
@@ -4,6 +4,7 @@ import { Separator } from '@/components/ui/separator'
 import type { ProjectResponse } from '@/types/ProjectResponse'
 import { getRoleDisplayName, sortParticipants } from '@/utils/roleMapper'
 import { ProjectResourcesPanel } from '@/components/ProjectResourcesPanel'
+import { formatToLocaleDateString, getYear } from '@/lib/dateUtils'
 
 interface ProjectDetailDialogProps {
   project: ProjectResponse | null
@@ -32,7 +33,7 @@ export function ProjectDetailDialog({ project, open, onOpenChange }: ProjectDeta
                 <span className="text-sm text-muted-foreground">{project.career.name}</span>
                 {project.initialSubmission && (
                   <span className="text-sm text-muted-foreground">
-                    • {new Date(project.initialSubmission).getFullYear()}
+                    • {getYear(project.initialSubmission)}
                   </span>
                 )}
               </div>
@@ -84,11 +85,11 @@ export function ProjectDetailDialog({ project, open, onOpenChange }: ProjectDeta
               <div className="space-y-1 text-sm">
                 <div>
                   <span className="font-medium">Consejo:</span>{' '}
-                  {new Date(project.initialSubmission).toLocaleDateString('es-ES')}
+                  {formatToLocaleDateString(project.initialSubmission)}
                 </div>
                 <div>
                   <span className="font-medium">Finalización:</span>{' '}
-                  {project.completion ? new Date(project.completion).toLocaleDateString('es-ES') : <span className="italic text-amber-600">pendiente</span>}
+                  {project.completion ? formatToLocaleDateString(project.completion) : <span className="italic text-amber-600">pendiente</span>}
                 </div>
               </div>
             </div>

--- a/src/components/ProjectTable.tsx
+++ b/src/components/ProjectTable.tsx
@@ -10,6 +10,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ProjectViewSheet } from '@/components/ProjectViewSheet';
 import { ProjectTagsSheet } from '@/components/ProjectTagsSheet';
 import { ProjectCompletionSheet } from '@/components/ProjectCompletionSheet';
+import { formatToLocaleDateString } from '@/lib/dateUtils';
 
 const TYPE_LABELS: Record<string,string> = { THESIS: 'Tesis', FINAL_PROJECT: 'Proyecto Final' };
 const SUBTYPE_LABELS: Record<string,string> = { 
@@ -186,7 +187,7 @@ export default function ProjectsTable() {
 		{
 			id: "submissionDate",
 			header: "Fecha de Presentación",
-			accessor: (row) => row.completion ? new Date(row.completion).toLocaleDateString('es-ES') : '—',
+			accessor: (row) => row.completion ? formatToLocaleDateString(row.completion) : '—',
 			sortField: "completion",
 			className: "whitespace-nowrap text-sm",
 		},

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,37 +1,21 @@
 /**
- * Parse a date string in ISO 8601 format (YYYY-MM-DD) without timezone conversion.
- * This is crucial for LocalDate values from the backend that should not be
- * interpreted with timezone offset.
+ * Format a date string (YYYY-MM-DD) to Spanish locale format without parsing.
+ * Avoids timezone offset issues by treating the string directly.
  * 
  * @param dateString - ISO date string (e.g., "2023-12-25")
- * @returns Date object in UTC time (prevents timezone offset issues)
- */
-export function parseLocalDate(dateString: string): Date {
-  // Split the date string to get components
-  const [year, month, day] = dateString.split('-').map(Number);
-  // Create date in UTC to avoid timezone offset interpretation
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-/**
- * Format a date string to Spanish locale format.
- * Handles both Date objects and ISO date strings.
- * 
- * @param dateInput - Date object or ISO date string
  * @returns Formatted date string (e.g., "25/12/2023")
  */
-export function formatToLocaleDateString(dateInput: string | Date): string {
-  const date = typeof dateInput === 'string' ? parseLocalDate(dateInput) : dateInput;
-  return date.toLocaleDateString('es-ES');
+export function formatToLocaleDateString(dateString: string): string {
+  const [year, month, day] = dateString.split('-');
+  return `${day}/${month}/${year}`;
 }
 
 /**
- * Get the year from a date string or Date object.
+ * Get the year from a date string (YYYY-MM-DD).
  * 
- * @param dateInput - Date object or ISO date string
+ * @param dateString - ISO date string (e.g., "2023-12-25")
  * @returns Year as number
  */
-export function getYear(dateInput: string | Date): number {
-  const date = typeof dateInput === 'string' ? parseLocalDate(dateInput) : dateInput;
-  return date.getUTCFullYear();
+export function getYear(dateString: string): number {
+  return parseInt(dateString.split('-')[0], 10);
 }

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Parse a date string in ISO 8601 format (YYYY-MM-DD) without timezone conversion.
+ * This is crucial for LocalDate values from the backend that should not be
+ * interpreted with timezone offset.
+ * 
+ * @param dateString - ISO date string (e.g., "2023-12-25")
+ * @returns Date object in UTC time (prevents timezone offset issues)
+ */
+export function parseLocalDate(dateString: string): Date {
+  // Split the date string to get components
+  const [year, month, day] = dateString.split('-').map(Number);
+  // Create date in UTC to avoid timezone offset interpretation
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Format a date string to Spanish locale format.
+ * Handles both Date objects and ISO date strings.
+ * 
+ * @param dateInput - Date object or ISO date string
+ * @returns Formatted date string (e.g., "25/12/2023")
+ */
+export function formatToLocaleDateString(dateInput: string | Date): string {
+  const date = typeof dateInput === 'string' ? parseLocalDate(dateInput) : dateInput;
+  return date.toLocaleDateString('es-ES');
+}
+
+/**
+ * Get the year from a date string or Date object.
+ * 
+ * @param dateInput - Date object or ISO date string
+ * @returns Year as number
+ */
+export function getYear(dateInput: string | Date): number {
+  const date = typeof dateInput === 'string' ? parseLocalDate(dateInput) : dateInput;
+  return date.getUTCFullYear();
+}

--- a/src/pages/public/BrowseProjectsPage.tsx
+++ b/src/pages/public/BrowseProjectsPage.tsx
@@ -11,6 +11,7 @@ import { ChevronLeft, ChevronRight, Search } from 'lucide-react'
 import { ProjectDetailDialog } from '@/components/ProjectDetailDialog'
 import { getRoleDisplayName, sortParticipants } from '@/utils/roleMapper'
 import type { ProjectResponse } from '@/types/ProjectResponse'
+import { formatToLocaleDateString, getYear } from '@/lib/dateUtils'
 
 export function BrowseProjectsPage() {
   const { filters } = useAnalyticsFilters()
@@ -88,7 +89,7 @@ export function BrowseProjectsPage() {
                       {project.initialSubmission && (
                         <>
                           <span>•</span>
-                          <span>{new Date(project.initialSubmission).getFullYear()}</span>
+                          <span>{getYear(project.initialSubmission)}</span>
                         </>
                       )}
                     </div>
@@ -147,10 +148,10 @@ export function BrowseProjectsPage() {
                   {/* Dates */}
                   <div className="text-xs text-muted-foreground space-y-1 pt-2 border-t">
                     <div>
-                      <span className="font-medium">Consejo:</span> {new Date(project.initialSubmission).toLocaleDateString('es-ES')}
+                      <span className="font-medium">Consejo:</span> {formatToLocaleDateString(project.initialSubmission)}
                     </div>
                     <div>
-                      <span className="font-medium">Finalización:</span> {project.completion ? new Date(project.completion).toLocaleDateString('es-ES') : <span className="italic text-amber-600">pendiente</span>}
+                      <span className="font-medium">Finalización:</span> {project.completion ? formatToLocaleDateString(project.completion) : <span className="italic text-amber-600">pendiente</span>}
                     </div>
                   </div>
                 </CardContent>


### PR DESCRIPTION
## Problem
LocalDate values from the backend were being parsed with JavaScript's Date constructor, which interprets them according to the client's timezone, causing date mismatches (e.g., showing 18 instead of 19).

## Solution
Created simple string manipulation utilities that work directly with ISO format dates (YYYY-MM-DD) without any parsing or timezone conversion, and updated all components to use them:

- `formatToLocaleDateString('2024-12-19')` → `'19/12/2024'`
- `getYear('2024-12-19')` → `2024`

## Files Changed
- Created `src/lib/dateUtils.ts` with timezone-safe date utilities
- Updated `ProjectTable.tsx`, `ProjectDetailDialog.tsx`, `BrowseProjectsPage.tsx` to use the new utilities

## Testing
✅ Dates now display consistently regardless of client timezone