### PR TITLE
fix: improve timeline pane and analytics dashboard

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -8,16 +8,65 @@ const Tabs = TabsPrimitive.Root
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const [indicatorStyle, setIndicatorStyle] = React.useState({ width: 0, left: 0 })
+  const listRef = React.useRef<HTMLDivElement>(null)
+
+  const updateIndicator = React.useCallback(() => {
+    if (!listRef.current) return
+    const activeButton = listRef.current.querySelector('[data-state="active"]')
+    if (activeButton) {
+      const rect = activeButton.getBoundingClientRect()
+      const listRect = listRef.current.getBoundingClientRect()
+      setIndicatorStyle({
+        width: rect.width,
+        left: rect.left - listRect.left,
+      })
+    }
+  }, [])
+
+  React.useEffect(() => {
+    updateIndicator()
+    const resizeObserver = new ResizeObserver(updateIndicator)
+    if (listRef.current) resizeObserver.observe(listRef.current)
+    
+    // Watch for tab changes
+    const observer = new MutationObserver(updateIndicator)
+    if (listRef.current) {
+      observer.observe(listRef.current, { attributes: true, subtree: true, attributeFilter: ['data-state'] })
+    }
+    
+    return () => {
+      resizeObserver.disconnect()
+      observer.disconnect()
+    }
+  }, [updateIndicator])
+
+  return (
+    <TabsPrimitive.List
+      ref={(node) => {
+        listRef.current = node
+        if (typeof ref === 'function') ref(node)
+        else if (ref) ref.current = node
+      }}
+      className={cn(
+        "relative inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      <div
+        className="absolute bottom-1 rounded-sm bg-background shadow-sm transition-all duration-300 ease-out"
+        style={{
+          width: `${indicatorStyle.width}px`,
+          left: `${indicatorStyle.left}px`,
+          height: 'calc(100% - 8px)',
+        }}
+      />
+      {props.children}
+    </TabsPrimitive.List>
+  )
+})
 TabsList.displayName = TabsPrimitive.List.displayName
 
 const TabsTrigger = React.forwardRef<
@@ -27,7 +76,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "relative inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground",
       className
     )}
     {...props}

--- a/src/pages/public/AnalyticsDashboardPage.tsx
+++ b/src/pages/public/AnalyticsDashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { AnalyticsFilters } from '@/pages/public/filters/AnalyticsFilters'
 import { TimelineChart } from '@/pages/public/charts/TimelineChart'
 import { TopicsHeatmap } from '@/pages/public/charts/TopicsHeatmap'
@@ -12,6 +13,13 @@ import { AnalyticsProvider } from '@/pages/public/AnalyticsContext'
 function AnalyticsDashboardContent() {
   const [activeTab, setActiveTab] = useState('timeline')
 
+  const tabOptions = [
+    { value: 'timeline', label: 'Barras por Año' },
+    { value: 'heatmap', label: 'Mapa de Calor' },
+    { value: 'network', label: 'Red' },
+    { value: 'stats', label: 'Estadísticas' },
+  ]
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
       {/* Sidebar Filters */}
@@ -21,8 +29,25 @@ function AnalyticsDashboardContent() {
 
       {/* Main Content */}
       <div className="lg:col-span-3 space-y-6">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 bg-white rounded-lg border border-slate-200 shadow-sm p-4">
+        {/* Mobile Dropdown */}
+        <div className="lg:hidden">
+          <Select value={activeTab} onValueChange={setActiveTab}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {tabOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Desktop Tabs */}
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="hidden lg:block w-full">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="timeline" className="text-xs sm:text-sm">
               Barras por Año
             </TabsTrigger>
@@ -36,27 +61,21 @@ function AnalyticsDashboardContent() {
               Estadísticas
             </TabsTrigger>
           </TabsList>
+        </Tabs>
 
-          <TabsContent value="timeline" className="mt-6">
-            <TimelineChart />
-          </TabsContent>
-
-          <TabsContent value="heatmap" className="mt-6">
-            <TopicsHeatmap />
-          </TabsContent>
-
-          <TabsContent value="network" className="mt-6">
-            <ProfessorNetwork />
-          </TabsContent>
-
-          <TabsContent value="stats" className="mt-6">
+        {/* Content */}
+        <div>
+          {activeTab === 'timeline' && <TimelineChart />}
+          {activeTab === 'heatmap' && <TopicsHeatmap />}
+          {activeTab === 'network' && <ProfessorNetwork />}
+          {activeTab === 'stats' && (
             <div className="space-y-6">
               <DashboardStats />
               <ProjectTypeStats />
               <StatsTable />
             </div>
-          </TabsContent>
-        </Tabs>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- Add slider animation to tabs with smooth transitions
- Make timeline chart responsive: no horizontal scroll on desktop, allows scroll on mobile
- Hide legend when more than 5 series to prevent overlap
- Add custom sorted tooltip showing values highest to lowest
- Convert bar chart to line chart for better trend visualization
- Add mobile dropdown selector for chart views on small screens
- Keep desktop tab bar with animated slider indicator